### PR TITLE
make string splitting faster

### DIFF
--- a/esm/DxfParser.d.ts
+++ b/esm/DxfParser.d.ts
@@ -107,6 +107,6 @@ export default class DxfParser {
     registerEntityHandler(handlerType: new () => IGeometry): void;
     parseSync(source: string): IDxf | null;
     parseStream(stream: Readable): Promise<IDxf>;
-    private StringSplitter;
+    private _splitStringByNewline;
     private _parse;
 }

--- a/esm/DxfParser.d.ts
+++ b/esm/DxfParser.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="node" />
 import { Readable } from 'stream';
 import IGeometry, { IEntity, IPoint } from './entities/geomtry.js';
 export interface IBlock {
@@ -106,5 +107,6 @@ export default class DxfParser {
     registerEntityHandler(handlerType: new () => IGeometry): void;
     parseSync(source: string): IDxf | null;
     parseStream(stream: Readable): Promise<IDxf>;
+    private StringSplitter;
     private _parse;
 }

--- a/esm/DxfParser.js
+++ b/esm/DxfParser.js
@@ -84,10 +84,23 @@ export default class DxfParser {
             });
         });
     }
+    StringSplitter(str) {
+        const lines = [];
+        let currentIndex = 0;
+        let nextIndex;
+        while ((nextIndex = str.indexOf('\n', currentIndex)) !== -1) {
+            lines.push(str.substring(currentIndex, nextIndex));
+            currentIndex = nextIndex + 1;
+        }
+        if (currentIndex < str.length) {
+            lines.push(str.substring(currentIndex));
+        }
+        return lines;
+    }
     _parse(dxfString) {
         const dxf = {};
         let lastHandle = 0;
-        const dxfLinesArray = dxfString.split(/\r\n|\r|\n/g);
+        const dxfLinesArray = this.StringSplitter(dxfString);
         const scanner = new DxfArrayScanner(dxfLinesArray);
         if (!scanner.hasNext())
             throw Error('Empty file');

--- a/esm/DxfParser.js
+++ b/esm/DxfParser.js
@@ -84,23 +84,34 @@ export default class DxfParser {
             });
         });
     }
-    StringSplitter(str) {
+    _splitStringByNewline(str) {
         const lines = [];
         let currentIndex = 0;
         let nextIndex;
+        // Split by \n
         while ((nextIndex = str.indexOf('\n', currentIndex)) !== -1) {
-            lines.push(str.substring(currentIndex, nextIndex));
+            let line = str.substring(currentIndex, nextIndex);
+            // Check if the line ends with a carriage return and remove it
+            if (line.endsWith('\r')) {
+                line = line.slice(0, -1); // Remove trailing \r if present (Windows-style)
+            }
+            lines.push(line);
             currentIndex = nextIndex + 1;
         }
         if (currentIndex < str.length) {
-            lines.push(str.substring(currentIndex));
+            let line = str.substring(currentIndex);
+            if (line.endsWith('\r')) {
+                line = line.slice(0, -1); // Remove trailing \r if present (Windows-style)
+            }
+            lines.push(line);
         }
         return lines;
     }
+    ;
     _parse(dxfString) {
         const dxf = {};
         let lastHandle = 0;
-        const dxfLinesArray = this.StringSplitter(dxfString);
+        const dxfLinesArray = this._splitStringByNewline(dxfString);
         const scanner = new DxfArrayScanner(dxfLinesArray);
         if (!scanner.hasNext())
             throw Error('Empty file');

--- a/src/DxfParser.ts
+++ b/src/DxfParser.ts
@@ -212,27 +212,37 @@ export default class DxfParser {
 		});
 	}
 
-	private StringSplitter(str: string) {
+	private _splitStringByNewline(str: string) {
 		const lines = [];
 		let currentIndex = 0;
 		let nextIndex;
 
+		// Split by \n
 		while ((nextIndex = str.indexOf('\n', currentIndex)) !== -1) {
-			lines.push(str.substring(currentIndex, nextIndex));
+			let line = str.substring(currentIndex, nextIndex);
+			// Check if the line ends with a carriage return and remove it
+			if (line.endsWith('\r')) {
+				line = line.slice(0, -1); // Remove trailing \r if present (Windows-style)
+			}
+			lines.push(line);
 			currentIndex = nextIndex + 1;
 		}
 
 		if (currentIndex < str.length) {
-			lines.push(str.substring(currentIndex));
+			let line = str.substring(currentIndex);
+			if (line.endsWith('\r')) {
+				line = line.slice(0, -1); // Remove trailing \r if present (Windows-style)
+			}
+			lines.push(line);
 		}
 
 		return lines;
-	}
+	};
 
 	private _parse(dxfString: string) {
 		const dxf = {} as IDxf;
 		let lastHandle = 0;
-		const dxfLinesArray = this.StringSplitter(dxfString);
+		const dxfLinesArray = this._splitStringByNewline(dxfString);
 
 		const scanner = new DxfArrayScanner(dxfLinesArray);
 		if (!scanner.hasNext()) throw Error('Empty file');

--- a/src/DxfParser.ts
+++ b/src/DxfParser.ts
@@ -212,10 +212,27 @@ export default class DxfParser {
 		});
 	}
 
+	private StringSplitter(str: string) {
+		const lines = [];
+		let currentIndex = 0;
+		let nextIndex;
+
+		while ((nextIndex = str.indexOf('\n', currentIndex)) !== -1) {
+			lines.push(str.substring(currentIndex, nextIndex));
+			currentIndex = nextIndex + 1;
+		}
+
+		if (currentIndex < str.length) {
+			lines.push(str.substring(currentIndex));
+		}
+
+		return lines;
+	}
+
 	private _parse(dxfString: string) {
 		const dxf = {} as IDxf;
 		let lastHandle = 0;
-		const dxfLinesArray = dxfString.split(/\r\n|\r|\n/g);
+		const dxfLinesArray = this.StringSplitter(dxfString);
 
 		const scanner = new DxfArrayScanner(dxfLinesArray);
 		if (!scanner.hasNext()) throw Error('Empty file');


### PR DESCRIPTION
Using regex was making string splitting dreadfully slow. Moving to some good old fashioned indexOf('\n') made it ~24x faster

Before:
<img width="602" alt="Screenshot 2024-06-20 at 5 39 04 PM" src="https://github.com/gdsestimating/dxf-parser/assets/33179100/d4deab9d-0cc5-421a-87b5-ba1af8bbdb26">

After:
<img width="599" alt="Screenshot 2024-06-20 at 5 39 53 PM" src="https://github.com/gdsestimating/dxf-parser/assets/33179100/1a5bf3a5-db31-4115-90cf-af157dc91e2d">