### PR TITLE
parse extrusion direction for Ellipse Entity

### DIFF
--- a/src/entities/ellipse.ts
+++ b/src/entities/ellipse.ts
@@ -9,6 +9,9 @@ export interface IEllipseEntity extends IEntity {
 	startAngle: number;
 	endAngle: number;
 	name: string;
+	extrusionDirectionX: number;
+	extrusionDirectionY: number;
+	extrusionDirectionZ: number;
 }
 
 export default class Ellipse implements IGeometry {
@@ -37,6 +40,15 @@ export default class Ellipse implements IGeometry {
 					break;
 				case 2:
 					entity.name = curr.value as string;
+					break;
+				case 210:
+					entity.extrusionDirectionX = curr.value as number;
+					break;
+				case 220:
+					entity.extrusionDirectionY = curr.value as number;
+					break;
+				case 230:
+					entity.extrusionDirectionZ = curr.value as number;
 					break;
 				default: // check common entity attributes
 					helpers.checkCommonEntityProperties(entity, curr, scanner);


### PR DESCRIPTION
dxf-parser was not adding codes 210, 220, or 230 to Ellipse Entities which expresses Extrusion Direction, this info is necessary to determine if a ellipse needs to be flipped about an axis to be represented correctly