### PR TITLE
consolidate console logs

### DIFF
--- a/esm/DxfArrayScanner.d.ts
+++ b/esm/DxfArrayScanner.d.ts
@@ -38,3 +38,17 @@ export default class DxfArrayScanner {
      */
     isEOF(): boolean;
 }
+/**
+ * Reset the unrecognized group code counters.
+ * Call this before parsing a new DXF file if you want per-file warnings.
+ */
+export declare function resetUndefinedTypeWarnings(): void;
+/**
+ * Get the count of unrecognized group code warnings encountered.
+ */
+export declare function getUndefinedTypeWarningCount(): number;
+/**
+ * Log a summary of unrecognized group codes if any occurred.
+ * Call this after parsing to see a consolidated warning.
+ */
+export declare function logUndefinedTypeWarningSummary(): void;

--- a/esm/DxfParser.js
+++ b/esm/DxfParser.js
@@ -1,15 +1,15 @@
-import DxfArrayScanner from './DxfArrayScanner.js';
 import AUTO_CAD_COLOR_INDEX from './AutoCadColorIndex.js';
+import DxfArrayScanner, { logUndefinedTypeWarningSummary, resetUndefinedTypeWarnings } from './DxfArrayScanner.js';
 import Face from './entities/3dface.js';
 import Arc from './entities/arc.js';
 import AttDef from './entities/attdef.js';
 import Circle from './entities/circle.js';
 import Dimension from './entities/dimension.js';
-import MLeader from './entities/mleader.js';
 import Ellipse from './entities/ellipse.js';
 import Insert from './entities/insert.js';
 import Line from './entities/line.js';
 import LWPolyline from './entities/lwpolyline.js';
+import MLeader from './entities/mleader.js';
 import MText from './entities/mtext.js';
 import Point from './entities/point.js';
 import Polyline from './entities/polyline.js';
@@ -109,6 +109,8 @@ export default class DxfParser {
     }
     ;
     _parse(dxfString) {
+        // Reset warning counters for this parse operation
+        resetUndefinedTypeWarnings();
         const dxf = {};
         let lastHandle = 0;
         const dxfLinesArray = this._splitStringByNewline(dxfString);
@@ -715,8 +717,14 @@ export default class DxfParser {
             if (!entity.handle)
                 entity.handle = lastHandle++;
         }
-        parseAll();
-        return dxf;
+        try {
+            parseAll();
+            return dxf;
+        }
+        finally {
+            // Log consolidated warning summary if any undefined type warnings occurred
+            logUndefinedTypeWarningSummary();
+        }
     }
 }
 function groupIs(group, code, value) {

--- a/src/DxfArrayScanner.ts
+++ b/src/DxfArrayScanner.ts
@@ -101,6 +101,42 @@ export default class DxfArrayScanner {
 	}
 }
 
+// Track unrecognized group codes to consolidate into a summary
+let unrecognizedGroupCodeCount = 0;
+let unrecognizedGroupCodes: Array<{ code: number; value: string }> = [];
+let seenGroupCodeKeys = new Set<string>();
+const MAX_UNIQUE_CODES = 100;
+
+/**
+ * Reset the unrecognized group code counters.
+ * Call this before parsing a new DXF file if you want per-file warnings.
+ */
+export function resetUndefinedTypeWarnings() {
+	unrecognizedGroupCodeCount = 0;
+	unrecognizedGroupCodes = [];
+	seenGroupCodeKeys.clear();
+}
+
+/**
+ * Get the count of unrecognized group code warnings encountered.
+ */
+export function getUndefinedTypeWarningCount(): number {
+	return unrecognizedGroupCodeCount;
+}
+
+/**
+ * Log a summary of unrecognized group codes if any occurred.
+ * Call this after parsing to see a consolidated warning.
+ */
+export function logUndefinedTypeWarningSummary() {
+	if (unrecognizedGroupCodeCount > 0) {
+		console.warn(
+			`DXF Parser: Encountered ${unrecognizedGroupCodeCount} unrecognized group code(s). ` +
+			`Unique codes (${unrecognizedGroupCodes.length}): ${JSON.stringify(unrecognizedGroupCodes)}`
+		);
+	}
+}
+
 /**
  * Parse a value to its proper type.
  * See pages 3 - 10 of the AutoCad DXF 2012 reference given at the top of this file
@@ -134,7 +170,13 @@ function parseGroupValue(code: number, value: string) {
 	if (code >= 1010 && code <= 1059) return parseFloat(value);
 	if (code >= 1060 && code <= 1071) return parseInt(value);
 
-	console.log('WARNING: Group code does not have a defined type: %j', { code: code, value: value });
+	// Track the unrecognized code instead of logging each occurrence
+	unrecognizedGroupCodeCount++;
+	const key = `${code}:${value}`;
+	if (!seenGroupCodeKeys.has(key) && unrecognizedGroupCodes.length < MAX_UNIQUE_CODES) {
+		seenGroupCodeKeys.add(key);
+		unrecognizedGroupCodes.push({ code, value });
+	}
 	return value;
 }
 

--- a/src/DxfParser.ts
+++ b/src/DxfParser.ts
@@ -1,17 +1,17 @@
 import { Readable } from 'stream';
-import DxfArrayScanner, { IGroup } from './DxfArrayScanner.js';
 import AUTO_CAD_COLOR_INDEX from './AutoCadColorIndex.js';
+import DxfArrayScanner, { IGroup, logUndefinedTypeWarningSummary, resetUndefinedTypeWarnings } from './DxfArrayScanner.js';
 
 import Face from './entities/3dface.js';
 import Arc from './entities/arc.js';
 import AttDef from './entities/attdef.js';
 import Circle from './entities/circle.js';
 import Dimension from './entities/dimension.js';
-import MLeader from './entities/mleader.js';
 import Ellipse from './entities/ellipse.js';
 import Insert from './entities/insert.js';
 import Line from './entities/line.js';
 import LWPolyline from './entities/lwpolyline.js';
+import MLeader from './entities/mleader.js';
 import MText from './entities/mtext.js';
 import Point from './entities/point.js';
 import Polyline from './entities/polyline.js';
@@ -240,6 +240,9 @@ export default class DxfParser {
 	};
 
 	private _parse(dxfString: string) {
+		// Reset warning counters for this parse operation
+		resetUndefinedTypeWarnings();
+
 		const dxf = {} as IDxf;
 		let lastHandle = 0;
 		const dxfLinesArray = this._splitStringByNewline(dxfString);
@@ -867,8 +870,13 @@ export default class DxfParser {
 			if (!entity.handle) entity.handle = lastHandle++;
 		}
 
-		parseAll();
-		return dxf;
+		try {
+			parseAll();
+			return dxf;
+		} finally {
+			// Log consolidated warning summary if any undefined type warnings occurred
+			logUndefinedTypeWarningSummary();
+		}
 	}
 }
 


### PR DESCRIPTION
Bad dxfs can create many many error/warnings - one bad dxf had 56k unrecognized group code warnings, instead of logging them individually let's pack em together