### PR TITLE
fix: handle LWPOLYLINE vertex identifier (group code 91)

### DIFF
--- a/esm/entities/lwpolyline.d.ts
+++ b/esm/entities/lwpolyline.d.ts
@@ -4,6 +4,7 @@ export interface IVertex extends IPoint {
     startWidth: number;
     endWidth: number;
     bulge: number;
+    id?: number;
 }
 export interface ILwpolylineEntity extends IEntity {
     vertices: IVertex[];

--- a/esm/entities/lwpolyline.js
+++ b/esm/entities/lwpolyline.js
@@ -84,6 +84,9 @@ function parseLWPolylineVertices(n, scanner) {
                     if (curr.value != 0)
                         vertex.bulge = curr.value;
                     break;
+                case 91: // vertex identifier (AcDbPolyline, R2010+)
+                    vertex.id = curr.value;
+                    break;
                 default:
                     // if we do not hit known code return vertices.  Code might belong to entity
                     scanner.rewind();

--- a/src/entities/lwpolyline.ts
+++ b/src/entities/lwpolyline.ts
@@ -6,6 +6,7 @@ export interface IVertex extends IPoint{
 	startWidth: number;
 	endWidth: number;
 	bulge: number;
+	id?: number;
 }
 
 export interface ILwpolylineEntity extends IEntity {
@@ -103,6 +104,9 @@ function parseLWPolylineVertices(n:number, scanner: DxfArrayScanner) {
 					break;
 				case 42: // bulge
 					if (curr.value != 0) vertex.bulge = curr.value as number;
+					break;
+				case 91: // vertex identifier (AcDbPolyline, R2010+)
+					vertex.id = curr.value as number;
 					break;
 				default:
 					// if we do not hit known code return vertices.  Code might belong to entity


### PR DESCRIPTION
## Problem
LWPOLYLINE entities authored by AutoCAD 2010+ carry a per-vertex identifier (group code 91) in their `AcDbPolyline` vertex lists. These polylines lost most of their vertices on parse — the dropped vertices come back as `undefined` x/y, which consumers render at the origin (0,0,0), producing stray line-ends spiking to 0,0.

## Root cause
`parseLWPolylineVertices` handles vertex group codes 10/20/30/40/41/42 and treats **any** other code as an entity-level terminator (`rewind` + return). Code 91 appears between vertices, so the reader bailed on the first 91; the outer `parseEntity` loop then re-entered the vertex reader on the next code 10, and the final pass captured only one real vertex while padding the array up to `numberOfVertices` with empty `{}` objects.

## Fix
Add a `case 91` that reads the value as the vertex identifier (`vertex.id`), so the reader no longer terminates on it and every 10/20 pair is read. `id?: number` added to `IVertex`.

## Validation
Reproduced with a real-world survey DXF (576 LWPOLYLINEs, 306 code-91 occurrences): origin-spike segments dropped from **20 → 0**, all previously-dropped vertices recovered, confirmed end-to-end through the consuming app.

## Testing in pringle
In pringle's `package.json`, point dxf-parser at this fix:
```json
"dxf-parser": "github:hypar-io/dxf-parser#50ce2f6"
```
Then:
```bash
npm install
rm -rf node_modules/.vite   # force Vite to re-bundle the dep
```
Restart the dev server, hard-reload, and re-import your DXF. LWPOLYLINEs with
vertex identifiers (AutoCAD 2010+) will no longer drop vertices to the origin.

BEFORE:
<img width="612" height="894" alt="Screenshot 2026-06-04 at 1 11 51 PM" src="https://github.com/user-attachments/assets/515d2699-3964-40cb-bd85-86e59ca4b7ca" />

AFTER:
<img width="605" height="861" alt="Screenshot 2026-06-04 at 1 10 52 PM" src="https://github.com/user-attachments/assets/6ffe8bbf-9ddf-459e-ac84-120f3adf9459" />

https://www.dropbox.com/scl/fi/55ksogwh064ly316hri0q/OFICINAS-GRUPO-MONCAYO.dxf?rlkey=i61j46xkkbk7ticrdzkwirp2y&dl=0
