### PR TITLE
feat: parse STYLE table, text style name, and font flags

### DIFF
--- a/esm/DxfParser.d.ts
+++ b/esm/DxfParser.d.ts
@@ -70,10 +70,27 @@ export interface ILayerTableDefinition {
     dxfSymbolName: 'LAYER';
     parseTableRecords(): Record<string, ILayer>;
 }
+export interface ITextStyle {
+    name: string;
+    flags: number;
+    fixedTextHeight: number;
+    widthFactor: number;
+    obliqueAngle: number;
+    fontFileName: string;
+    bigFontFileName: string;
+    fontFlags?: number;
+}
+export interface IStyleTableDefinition {
+    tableRecordsProperty: 'styles';
+    tableName: 'style';
+    dxfSymbolName: 'STYLE';
+    parseTableRecords(): Record<string, ITextStyle>;
+}
 export interface ITableDefinitions {
     VPORT: IViewPortTableDefinition;
     LTYPE: ILineTypeTableDefinition;
     LAYER: ILayerTableDefinition;
+    STYLE: IStyleTableDefinition;
 }
 export interface IBaseTable {
     handle: string;
@@ -88,12 +105,16 @@ export interface ILayerTypesTable extends IBaseTable {
 export interface ILayersTable extends IBaseTable {
     layers: Record<string, ILayer>;
 }
+export interface IStyleTable extends IBaseTable {
+    styles: Record<string, ITextStyle>;
+}
 export interface ITables {
     viewPort: IViewPortTable;
     lineType: ILayerTypesTable;
     layer: ILayersTable;
+    style: IStyleTable;
 }
-export type ITable = IViewPortTable | ILayerTypesTable | ILayersTable;
+export type ITable = IViewPortTable | ILayerTypesTable | ILayersTable | IStyleTable;
 export interface IDxf {
     header: Record<string, IPoint | number>;
     entities: IEntity[];

--- a/esm/DxfParser.js
+++ b/esm/DxfParser.js
@@ -625,6 +625,67 @@ export default class DxfParser {
             layers[layerName] = layer;
             return layers;
         }
+        function parseStyles() {
+            const styles = {};
+            let style = {};
+            let styleName;
+            log.debug('Style {');
+            curr = scanner.next();
+            while (!groupIs(curr, 0, 'ENDTAB')) {
+                switch (curr.code) {
+                    case 2: // style name
+                        style.name = curr.value;
+                        styleName = curr.value;
+                        curr = scanner.next();
+                        break;
+                    case 3: // primary font file name
+                        style.fontFileName = curr.value;
+                        curr = scanner.next();
+                        break;
+                    case 4: // bigfont file name
+                        style.bigFontFileName = curr.value;
+                        curr = scanner.next();
+                        break;
+                    case 40: // fixed text height
+                        style.fixedTextHeight = curr.value;
+                        curr = scanner.next();
+                        break;
+                    case 41: // width factor
+                        style.widthFactor = curr.value;
+                        curr = scanner.next();
+                        break;
+                    case 50: // oblique angle
+                        style.obliqueAngle = curr.value;
+                        curr = scanner.next();
+                        break;
+                    case 70: // flags
+                        style.flags = curr.value;
+                        curr = scanner.next();
+                        break;
+                    case 1071: // ACAD XData: TrueType font flags (italic/bold)
+                        style.fontFlags = curr.value;
+                        curr = scanner.next();
+                        break;
+                    case 0:
+                        if (curr.value === 'STYLE') {
+                            log.debug('}');
+                            styles[styleName] = style;
+                            log.debug('Style {');
+                            style = {};
+                            styleName = undefined;
+                            curr = scanner.next();
+                        }
+                        break;
+                    default:
+                        logUnhandledGroup(curr);
+                        curr = scanner.next();
+                        break;
+                }
+            }
+            log.debug('}');
+            styles[styleName] = style;
+            return styles;
+        }
         const tableDefinitions = {
             VPORT: {
                 tableRecordsProperty: 'viewPorts',
@@ -643,6 +704,12 @@ export default class DxfParser {
                 tableName: 'layer',
                 dxfSymbolName: 'LAYER',
                 parseTableRecords: parseLayers
+            },
+            STYLE: {
+                tableRecordsProperty: 'styles',
+                tableName: 'style',
+                dxfSymbolName: 'STYLE',
+                parseTableRecords: parseStyles
             }
         };
         /**

--- a/esm/entities/mtext.d.ts
+++ b/esm/entities/mtext.d.ts
@@ -9,6 +9,7 @@ export interface IMtextEntity extends IEntity {
     rotation: number;
     attachmentPoint: number;
     drawingDirection: number;
+    styleName?: string;
 }
 export default class Mtext implements IGeometry {
     ForEntityName: "MTEXT";

--- a/esm/entities/mtext.js
+++ b/esm/entities/mtext.js
@@ -14,6 +14,9 @@ export default class Mtext {
                 case 1:
                     entity.text ? entity.text += curr.value : entity.text = curr.value;
                     break;
+                case 7:
+                    entity.styleName = curr.value;
+                    break;
                 case 10:
                     entity.position = helpers.parsePoint(scanner);
                     break;

--- a/esm/entities/text.d.ts
+++ b/esm/entities/text.d.ts
@@ -9,6 +9,7 @@ export interface ITextEntity extends IEntity {
     text: string;
     halign: number;
     valign: number;
+    styleName?: string;
 }
 export default class Text implements IGeometry {
     ForEntityName: "TEXT";

--- a/esm/entities/text.js
+++ b/esm/entities/text.js
@@ -26,6 +26,9 @@ export default class Text {
                 case 1: // Text
                     entity.text = curr.value;
                     break;
+                case 7: // text style name
+                    entity.styleName = curr.value;
+                    break;
                 // NOTE: 72 and 73 are meaningless without 11 (second alignment point)
                 case 72: // Horizontal alignment
                     entity.halign = curr.value;

--- a/esm/index.d.ts
+++ b/esm/index.d.ts
@@ -1,5 +1,5 @@
 export { getUndefinedTypeWarningCount, logUndefinedTypeWarningSummary, resetUndefinedTypeWarnings } from './DxfArrayScanner.js';
-export { default, default as DxfParser, IBaseTable, IBlock, IDxf, ILayer, ILayersTable, ILayerTableDefinition, ILayerTypesTable, ILineType, ILineTypeTableDefinition, ITable, ITableDefinitions, ITables, IViewPort, IViewPortTable, IViewPortTableDefinition } from './DxfParser.js';
+export { default, default as DxfParser, IBaseTable, IBlock, IDxf, ILayer, ILayersTable, ILayerTableDefinition, ILayerTypesTable, ILineType, ILineTypeTableDefinition, IStyleTable, IStyleTableDefinition, ITable, ITableDefinitions, ITables, ITextStyle, IViewPort, IViewPortTable, IViewPortTableDefinition } from './DxfParser.js';
 export { I3DfaceEntity } from './entities/3dface.js';
 export { IArcEntity } from './entities/arc.js';
 export { IAttdefEntity } from './entities/attdef.js';

--- a/src/DxfParser.ts
+++ b/src/DxfParser.ts
@@ -107,10 +107,30 @@ export interface ILayerTableDefinition {
 	parseTableRecords(): Record<string, ILayer>;
 }
 
+export interface ITextStyle {
+	name: string;
+	flags: number;
+	fixedTextHeight: number;
+	widthFactor: number;
+	obliqueAngle: number;
+	fontFileName: string;
+	bigFontFileName: string;
+	// ACAD XData (group 1071): packed TrueType pitch/family/charset + italic (bit 24) / bold (bit 25).
+	fontFlags?: number;
+}
+
+export interface IStyleTableDefinition {
+	tableRecordsProperty: 'styles';
+	tableName: 'style';
+	dxfSymbolName: 'STYLE';
+	parseTableRecords(): Record<string, ITextStyle>;
+}
+
 export interface ITableDefinitions {
 	VPORT: IViewPortTableDefinition;
 	LTYPE: ILineTypeTableDefinition;
 	LAYER: ILayerTableDefinition;
+	STYLE: IStyleTableDefinition;
 }
 
 export interface IBaseTable {
@@ -130,13 +150,18 @@ export interface ILayersTable extends IBaseTable {
 	layers: Record<string, ILayer>;
 }
 
+export interface IStyleTable extends IBaseTable {
+	styles: Record<string, ITextStyle>;
+}
+
 export interface ITables {
 	viewPort: IViewPortTable;
 	lineType: ILayerTypesTable;
 	layer: ILayersTable;
+	style: IStyleTable;
 }
 
-export type ITable = IViewPortTable | ILayerTypesTable | ILayersTable;
+export type ITable = IViewPortTable | ILayerTypesTable | ILayersTable | IStyleTable;
 
 export interface IDxf {
 	header: Record<string, IPoint | number>;
@@ -770,6 +795,70 @@ export default class DxfParser {
 			return layers;
 		}
 
+		function parseStyles() {
+			const styles = {} as Record<string, ITextStyle>;
+			let style = {} as ITextStyle;
+			let styleName: string | undefined;
+
+			log.debug('Style {');
+			curr = scanner.next();
+			while (!groupIs(curr, 0, 'ENDTAB')) {
+				switch (curr.code) {
+					case 2: // style name
+						style.name = curr.value as string;
+						styleName = curr.value as string;
+						curr = scanner.next();
+						break;
+					case 3: // primary font file name
+						style.fontFileName = curr.value as string;
+						curr = scanner.next();
+						break;
+					case 4: // bigfont file name
+						style.bigFontFileName = curr.value as string;
+						curr = scanner.next();
+						break;
+					case 40: // fixed text height
+						style.fixedTextHeight = curr.value as number;
+						curr = scanner.next();
+						break;
+					case 41: // width factor
+						style.widthFactor = curr.value as number;
+						curr = scanner.next();
+						break;
+					case 50: // oblique angle
+						style.obliqueAngle = curr.value as number;
+						curr = scanner.next();
+						break;
+					case 70: // flags
+						style.flags = curr.value as number;
+						curr = scanner.next();
+						break;
+					case 1071: // ACAD XData: TrueType font flags (italic/bold)
+						style.fontFlags = curr.value as number;
+						curr = scanner.next();
+						break;
+					case 0:
+						if (curr.value === 'STYLE') {
+							log.debug('}');
+							styles[styleName!] = style;
+							log.debug('Style {');
+							style = {} as ITextStyle;
+							styleName = undefined;
+							curr = scanner.next();
+						}
+						break;
+					default:
+						logUnhandledGroup(curr);
+						curr = scanner.next();
+						break;
+				}
+			}
+			log.debug('}');
+			styles[styleName!] = style;
+
+			return styles;
+		}
+
 		const tableDefinitions = {
 			VPORT: {
 				tableRecordsProperty: 'viewPorts',
@@ -788,6 +877,12 @@ export default class DxfParser {
 				tableName: 'layer',
 				dxfSymbolName: 'LAYER',
 				parseTableRecords: parseLayers
+			},
+			STYLE: {
+				tableRecordsProperty: 'styles',
+				tableName: 'style',
+				dxfSymbolName: 'STYLE',
+				parseTableRecords: parseStyles
 			}
 		} as ITableDefinitions;
 

--- a/src/entities/mtext.ts
+++ b/src/entities/mtext.ts
@@ -11,6 +11,7 @@ export interface IMtextEntity extends IEntity {
 	rotation: number;
 	attachmentPoint: number;
 	drawingDirection: number;
+	styleName?: string;
 }
 
 export default class Mtext implements IGeometry {
@@ -27,6 +28,9 @@ export default class Mtext implements IGeometry {
 					break;
 				case 1:
 					entity.text ? entity.text += curr.value : entity.text = curr.value as string;
+					break;
+				case 7:
+					entity.styleName = curr.value as string;
 					break;
 				case 10:
 					entity.position = helpers.parsePoint(scanner);

--- a/src/entities/text.ts
+++ b/src/entities/text.ts
@@ -11,6 +11,7 @@ export interface ITextEntity extends IEntity {
 	text: string;
 	halign: number;
 	valign: number;
+	styleName?: string;
 }
 
 export default class Text implements IGeometry {
@@ -38,6 +39,9 @@ export default class Text implements IGeometry {
 					break;
 				case 1: // Text
 					entity.text = curr.value as string;
+					break;
+				case 7: // text style name
+					entity.styleName = curr.value as string;
 					break;
 				// NOTE: 72 and 73 are meaningless without 11 (second alignment point)
 				case 72: // Horizontal alignment

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { getUndefinedTypeWarningCount, logUndefinedTypeWarningSummary, resetUndefinedTypeWarnings } from './DxfArrayScanner.js';
-export { default, default as DxfParser, IBaseTable, IBlock, IDxf, ILayer, ILayersTable, ILayerTableDefinition, ILayerTypesTable, ILineType, ILineTypeTableDefinition, ITable, ITableDefinitions, ITables, IViewPort, IViewPortTable, IViewPortTableDefinition } from './DxfParser.js';
+export { default, default as DxfParser, IBaseTable, IBlock, IDxf, ILayer, ILayersTable, ILayerTableDefinition, ILayerTypesTable, ILineType, ILineTypeTableDefinition, IStyleTable, IStyleTableDefinition, ITable, ITableDefinitions, ITables, ITextStyle, IViewPort, IViewPortTable, IViewPortTableDefinition } from './DxfParser.js';
 export { I3DfaceEntity } from './entities/3dface.js';
 export { IArcEntity } from './entities/arc.js';
 export { IAttdefEntity } from './entities/attdef.js';


### PR DESCRIPTION
## Problem
TEXT and MTEXT entities reference a text style (group code 7) whose font, weight, and slant live in the STYLE symbol table — but the parser dropped both: the STYLE table was unhandled and the entity's style reference was never captured, so consumers had no way to resolve a text entity's configured font.

## Fix
- Parse the STYLE symbol table into `tables.style` (`IStyleTable`): name, flags, fixed text height, width factor, oblique angle, primary/bigfont file names, and the ACAD XData font flags (group code 1071) that carry a TrueType font's italic (bit 24) / bold (bit 25).
- Capture `styleName` on `ITextEntity` / `IMtextEntity` from group code 7.
- Export `ITextStyle`, `IStyleTable`, `IStyleTableDefinition`.

Additive — existing parsing is unchanged.

## Validation
Parsed a DXF with a STYLE table (including a TrueType style with XData 1071): every record resolves under `tables.style.styles`, `entity.styleName` is populated, and the 1071 bold/italic bits decode correctly. Confirmed end-to-end in pringle — imported DXF text renders in the style's configured weight/slant.

## Testing in pringle
In pringle's `package.json`, point dxf-parser at this branch:
```json
"dxf-parser": "github:hypar-io/dxf-parser#9337f21"
```
Then:
```bash
npm install
rm -rf node_modules/.vite   # force Vite to re-bundle the dep
```
Restart the dev server, hard-reload, and re-import a DXF with styled text.
